### PR TITLE
Put instance in its own stack to make it easier to delete and rebuild quickly.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -60,16 +60,27 @@ jobs:
             --stack-name ${{ env.STACK_NAME }} \
             --capabilities CAPABILITY_IAM \
             --no-fail-on-empty-changeset
+      - name: Validate Instance CloudFormation template
+        run: |
+          aws cloudformation validate-template \
+            --template-body file://cloudformation_dynamic/instance.yaml
+      - name: Deploy CloudFormation stack for instance
+        run: |
+          aws cloudformation deploy \
+            --template-file cloudformation_dynamic/instance.yaml \
+            --stack-name ${{ env.STACK_NAME }}-instance \
+            --capabilities CAPABILITY_IAM \
+            --no-fail-on-empty-changeset
 
       - name: Get stack outputs
         id: stack-outputs
         run: |
           PUBLIC_IP=$(aws cloudformation describe-stacks \
-            --stack-name ${{ env.STACK_NAME }} \
+            --stack-name ${{ env.STACK_NAME }}-instance \
             --query 'Stacks[0].Outputs[?OutputKey==`PublicIP`].OutputValue' \
             --output text)
           API_URL=$(aws cloudformation describe-stacks \
-            --stack-name ${{ env.STACK_NAME }} \
+            --stack-name ${{ env.STACK_NAME }}-instance \
             --query 'Stacks[0].Outputs[?OutputKey==`ApiUrl`].OutputValue' \
             --output text)
           echo "public-ip=$PUBLIC_IP" >> $GITHUB_OUTPUT
@@ -80,25 +91,25 @@ jobs:
           echo "Waiting for EC2 instance to be ready..."
           sleep 60
 
-      - name: Update application code
-        run: |
-          INSTANCE_ID=$(aws cloudformation describe-stacks \
-            --stack-name ${{ env.STACK_NAME }} \
-            --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' \
-            --output text)
+      # - name: Update application code
+      #   run: |
+      #     INSTANCE_ID=$(aws cloudformation describe-stacks \
+      #       --stack-name ${{ env.STACK_NAME }} \
+      #       --query 'Stacks[0].Outputs[?OutputKey==`InstanceId`].OutputValue' \
+      #       --output text)
           
-          # Send application code to instance via SSM
-          aws ssm send-command \
-            --instance-ids $INSTANCE_ID \
-            --document-name "AWS-RunShellScript" \
-            --parameters 'commands=[
-              "cd /opt/simplerestapi",
-              "cat > app.py << '\''EOF'\''",
-              "$(cat application/app.py)",
-              "EOF",
-              "systemctl restart simplerestapi"
-            ]' \
-            --output text
+      #     # Send application code to instance via SSM
+      #     aws ssm send-command \
+      #       --instance-ids $INSTANCE_ID \
+      #       --document-name "AWS-RunShellScript" \
+      #       --parameters 'commands=[
+      #         "cd /opt/simplerestapi",
+      #         "cat > app.py << '\''EOF'\''",
+      #         "$(cat application/app.py)",
+      #         "EOF",
+      #         "systemctl restart simplerestapi"
+      #       ]' \
+      #       --output text
 
       - name: Verify deployment
         run: |

--- a/cloudformation_dynamic/application.yaml
+++ b/cloudformation_dynamic/application.yaml
@@ -1,28 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
-Description: 'Simple REST API application deployed on EC2 with public IP'
-
-Parameters:
-  InstanceType:
-    Type: String
-    Description: EC2 instance type
-    Default: t3.micro
-    AllowedValues:
-      - t3.micro
-      - t3.small
-      - t3.medium
-
-  LatestAmiId:
-    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
-    Description: Latest Amazon Linux 2023 AMI ID
-    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
-
-  KeyName:
-    Type: String
-    Description: EC2 Key Pair name (optional, for SSH access)
-    Default: ''
-
-Conditions:
-  HasKeyName: !Not [!Equals [!Ref KeyName, '']]
+Description: 'Simple REST API application resources, excluding instance'
 
 Resources:
   VPC:
@@ -146,102 +123,20 @@ Resources:
       Roles:
         - !Ref InstanceRole
 
-  EC2Instance:
-    Type: AWS::EC2::Instance
-    Properties:
-      InstanceType: !Ref InstanceType
-      ImageId: !Ref LatestAmiId
-      IamInstanceProfile: !Ref InstanceProfile
-      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
-      NetworkInterfaces:
-        - AssociatePublicIpAddress: true
-          DeviceIndex: 0
-          GroupSet:
-            - !Ref InstanceSecurityGroup
-          SubnetId: !Ref PublicSubnet
-      UserData:
-        Fn::Base64: !Sub |
-          #!/bin/bash
-          set -e
-          
-          # Update system
-          yum update -y
-          # Install Nginx
-          sudo yum install -y nginx
-
-          systemctl enable nginx
-          systemctl start nginx
-          
-          # Install Python 3 and pip
-          yum install -y python3 python3-pip
-
-          # Copy dummy file from S3 bucket to /usr/share/nginx/html
-          mkdir -p /usr/share/nginx/html
-          aws s3 cp s3://simplerestapi-bucket-20251016/dummy.html /usr/share/nginx/html/dummy.html
-          
-          # Copy second dummy file from S3 bucket to /usr/share/nginx/html/secondary
-          mkdir -p /usr/share/nginx/html/secondary
-          aws s3 cp s3://simplerestapi-bucket-20251016/dummy2.html /usr/share/nginx/html/secondary/dummy2.html
-
-          # Copy custom Nginx configuration from S3 bucket
-          aws s3 cp s3://simplerestapi-bucket-20251016/webservice.conf /etc/nginx/default.d/webservice.conf
-          systemctl restart nginx
-
-          # Create application directory
-          mkdir -p /opt/simplerestapi
-          cd /opt/simplerestapi
-          
-          # Deploy the application to a location
-          aws s3 cp s3://simplerestapi-bucket-20251016/app.py /opt/simplerestapi/app.py
-          aws s3 cp s3://simplerestapi-bucket-20251016/requirements.txt /opt/simplerestapi/requirements.txt
-          pip3 install -r requirements.txt
-          
-          # Create systemd service
-          cat > /etc/systemd/system/simplerestapi.service << 'EOF'
-          [Unit]
-          Description=Simple REST API
-          After=network.target
-          
-          [Service]
-          Type=simple
-          User=root
-          WorkingDirectory=/opt/simplerestapi
-          ExecStart=/usr/bin/python3 /opt/simplerestapi/app.py
-          Restart=always
-          
-          [Install]
-          WantedBy=multi-user.target
-          EOF
-          
-          # Enable and start the service
-          systemctl daemon-reload
-          systemctl enable simplerestapi
-          systemctl start simplerestapi
-      Tags:
-        - Key: Name
-          Value: SimpleRestApiInstance
-
 Outputs:
-  InstanceId:
-    Description: EC2 Instance ID
-    Value: !Ref EC2Instance
+  InstanceProfileName:
+    Description: IAM Instance Profile for EC2 instance
+    Value: !Ref InstanceProfile
     Export:
-      Name: SimpleRestApiInstanceId
-
-  PublicIP:
-    Description: Public IP address of the EC2 instance
-    Value: !GetAtt EC2Instance.PublicIp
+      Name: InstanceProfile
+  InstanceSecurityGroup:
+    Description: Security Group for EC2 instance
+    Value: !Ref InstanceSecurityGroup
     Export:
-      Name: SimpleRestApiPublicIP
-
-  PublicDNS:
-    Description: Public DNS name of the EC2 instance
-    Value: !GetAtt EC2Instance.PublicDnsName
+      Name: InstanceSecurityGroup
+  PublicSubnet:
+    Description: Public Subnet ID
+    Value: !Ref PublicSubnet
     Export:
-      Name: SimpleRestApiPublicDNS
-
-  ApiUrl:
-    Description: URL to access the REST API
-    Value: !Sub 'http://${EC2Instance.PublicIp}:8080'
-    Export:
-      Name: SimpleRestApiUrl
+      Name: PublicSubnet
+  

--- a/cloudformation_dynamic/instance.yaml
+++ b/cloudformation_dynamic/instance.yaml
@@ -1,0 +1,127 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: 'Simple REST API application instance only'
+
+
+Parameters:
+  InstanceType:
+    Type: String
+    Description: EC2 instance type
+    Default: t3.micro
+    AllowedValues:
+      - t3.micro
+      - t3.small
+      - t3.medium
+
+  LatestAmiId:
+    Type: AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>
+    Description: Latest Amazon Linux 2023 AMI ID
+    Default: /aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64
+
+  KeyName:
+    Type: String
+    Description: EC2 Key Pair name (optional, for SSH access)
+    Default: ''
+
+Conditions:
+  HasKeyName: !Not [!Equals [!Ref KeyName, '']]
+
+
+Resources:
+  EC2Instance:
+    Type: AWS::EC2::Instance
+    Properties:
+      InstanceType: !Ref InstanceType
+      ImageId: !Ref LatestAmiId
+      IamInstanceProfile: !ImportValue InstanceProfile
+      KeyName: !If [HasKeyName, !Ref KeyName, !Ref 'AWS::NoValue']
+      NetworkInterfaces:
+        - AssociatePublicIpAddress: true
+          DeviceIndex: 0
+          GroupSet:
+            - !ImportValue InstanceSecurityGroup
+          SubnetId: !ImportValue PublicSubnet
+      UserData:
+        Fn::Base64: !Sub |
+          #!/bin/bash
+          set -e
+          
+          # Update system
+          yum update -y
+          # Install Nginx
+          sudo yum install -y nginx
+
+          systemctl enable nginx
+          systemctl start nginx
+          
+          # Install Python 3 and pip
+          yum install -y python3 python3-pip
+
+          # Copy dummy file from S3 bucket to /usr/share/nginx/html
+          mkdir -p /usr/share/nginx/html
+          aws s3 cp s3://simplerestapi-bucket-20251016/dummy.html /usr/share/nginx/html/dummy.html
+          
+          # Copy second dummy file from S3 bucket to /usr/share/nginx/html/secondary
+          mkdir -p /usr/share/nginx/html/secondary
+          aws s3 cp s3://simplerestapi-bucket-20251016/dummy2.html /usr/share/nginx/html/secondary/dummy2.html
+
+          # Copy custom Nginx configuration from S3 bucket
+          aws s3 cp s3://simplerestapi-bucket-20251016/webservice.conf /etc/nginx/default.d/webservice.conf
+          systemctl restart nginx
+
+          # Create application directory
+          mkdir -p /opt/simplerestapi
+          cd /opt/simplerestapi
+          
+          # Deploy the application to a location
+          aws s3 cp s3://simplerestapi-bucket-20251016/app.py /opt/simplerestapi/app.py
+          aws s3 cp s3://simplerestapi-bucket-20251016/requirements.txt /opt/simplerestapi/requirements.txt
+          pip3 install -r requirements.txt
+          
+          # Create systemd service
+          cat > /etc/systemd/system/simplerestapi.service << 'EOF'
+          [Unit]
+          Description=Simple REST API
+          After=network.target
+          
+          [Service]
+          Type=simple
+          User=root
+          WorkingDirectory=/opt/simplerestapi
+          ExecStart=/usr/bin/python3 /opt/simplerestapi/app.py
+          Restart=always
+          
+          [Install]
+          WantedBy=multi-user.target
+          EOF
+          
+          # Enable and start the service
+          systemctl daemon-reload
+          systemctl enable simplerestapi
+          systemctl start simplerestapi
+      Tags:
+        - Key: Name
+          Value: SimpleRestApiInstance
+
+  InstanceId:
+    Description: EC2 Instance ID
+    Value: !Ref EC2Instance
+    Export:
+      Name: SimpleRestApiInstanceId
+
+  PublicIP:
+    Description: Public IP address of the EC2 instance
+    Value: !GetAtt EC2Instance.PublicIp
+    Export:
+      Name: SimpleRestApiPublicIP
+
+  PublicDNS:
+    Description: Public DNS name of the EC2 instance
+    Value: !GetAtt EC2Instance.PublicDnsName
+    Export:
+      Name: SimpleRestApiPublicDNS
+
+  ApiUrl:
+    Description: URL to access the REST API
+    Value: !Sub 'http://${EC2Instance.PublicIp}:8080'
+    Export:
+      Name: SimpleRestApiUrl


### PR DESCRIPTION
This required moving the instance to a new file, exporting resource IDs from the main stack, importing those into the instance stack. And adding the instance stack to the set of stacks deployed.