### PR TITLE
Correct typo in path name.

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -74,7 +74,7 @@ jobs:
           aws s3 cp application/configuration/myproject.service s3://simplerestapi-bucket-20251016/myproject.service
           aws s3 cp application/configuration/myproject.socket s3://simplerestapi-bucket-20251016/myproject.socket
           aws s3 cp application/configuration/uwsgi.service s3://simplerestapi-bucket-20251016/uwsgi.service
-          aws s3 cp application/configuration/uwsgi.sockt s3://simplerestapi-bucket-20251016/uwsgi.socket
+          aws s3 cp application/configuration/uwsgi.socket s3://simplerestapi-bucket-20251016/uwsgi.socket
           
           aws s3 cp application/configuration/nginx.conf s3://simplerestapi-bucket-20251016/nginx.conf
 


### PR DESCRIPTION
Corrected an error in the path name.
This might mean that we can talk to uWSGI through a UNIX socket, and uWSGI is fully, automatically installed. Need to run the tests to find out.